### PR TITLE
Garage-geometry

### DIFF
--- a/ochre/utils/hpxml.py
+++ b/ochre/utils/hpxml.py
@@ -475,17 +475,18 @@ def parse_hpxml_zones(hpxml, boundaries, construction):
         # Get gable wall areas for attic and (possibly) garage
         attic_wall_areas = (boundaries.get('Attic Wall', {}).get('Area (m^2)', []) +
                             boundaries.get('Adjacent Attic Wall', {}).get('Area (m^2)', []))
-        if not has_garage and len(attic_wall_areas) == 2:
+        if len(attic_wall_areas) == 2:
+            # standard gable roof with attic
             assert abs(attic_wall_areas[1] - attic_wall_areas[0]) < 0.2  # computational errors possible
             attic_gable_area = attic_wall_areas[0]
             garage_gable_area = 0
         elif has_garage and len(attic_wall_areas) == 3:
-            # 2 attic gables, 1 garage gable, garage gable has area that is 'more different'
+            # 2 attic gables plus 1 garage gable, garage gable has area that is 'more different'
             attic_gable_area = attic_wall_areas[1]
             low, med, high = tuple(sorted(attic_wall_areas))
             garage_gable_area = low if med - low > high - med else high
         else:
-            raise Exception('Unable to parse gable wall areas.')
+            raise Exception('Unable to calculate attic area, likely an issue with gable walls.')
 
         # Get attic properties
         roof_tilt = convert(boundaries['Attic Roof']['Tilt (deg)'], 'deg',

--- a/ochre/utils/hpxml.py
+++ b/ochre/utils/hpxml.py
@@ -371,34 +371,46 @@ def parse_hpxml_boundaries(hpxml, return_boundary_dicts=False, **kwargs):
     else:
         raise IOError(f'Unable to parse multiple floor areas: {main_floor_areas}')
 
+    attic_floor_area = first_floor_area  # may get updated later
     if 'Garage Floor' in boundaries:
         garage_floor_area = boundaries['Garage Floor']['Area (m^2)'][0]
         attached_wall_lengths = [area / ceiling_height for area in boundaries['Garage Attached Wall']['Area (m^2)']]
-        if len(attached_wall_lengths) == 1:
+        attached_wall_azimuths = [wall['Azimuth'] % 180 for wall in attached_walls.values()]
+        n_sides = len(set(attached_wall_azimuths))
+        if n_sides == 1:
             garage_area_in_main = 0
-        elif len(attached_wall_lengths) == 2:
-            # at least part of garage is included in the main house footprint (note, house may not have 2nd floor)
-            garage_area_in_main = attached_wall_lengths[0] * attached_wall_lengths[1]
-            assert 0.1 < garage_area_in_main / garage_floor_area < 0.9  # should be close to 50% for ResStock cases
+            if total_floors == 1:
+                attic_floor_area += garage_floor_area
+        elif n_sides == 2:
+            # at least part of garage is included in the main house footprint
+            if len(attached_wall_lengths) == 2:
+                # usually for 1-story home or garage that is fully under the 2nd story
+                garage_area_in_main = attached_wall_lengths[0] * attached_wall_lengths[1]
+                attic_floor_area += garage_floor_area
+            elif len(attached_wall_lengths) == 3:
+                # usually for 2-story home with protruding garage. 2 regular walls + 1 gable wall
+                lengths = [max([l for l, a in zip(attached_wall_lengths, attached_wall_azimuths) if a == az])
+                           for az in set(attached_wall_azimuths)]
+                garage_area_in_main = lengths[0] * lengths[1]
+            assert 0 < garage_area_in_main / garage_floor_area < 1.001  # should be close to 50% for ResStock cases
         else:
             # TODO: Incorporate complex garage geometries, see BEopt examples
             print('WARNING: Garage area calculation is incorrect. Likely due to complex garage geometry.')
             garage_area_in_main = 0
-        second_floor_area = first_floor_area + garage_area_in_main
     else:
         garage_floor_area = 0
-        second_floor_area = first_floor_area
-    conditioned_floor_check = first_floor_area * total_floors + garage_floor_area * (indoor_floors - 1)
-    if abs(conditioned_floor_area - conditioned_floor_check) < 0.1:
-        indoor_floor_area = first_floor_area * indoor_floors + garage_floor_area * (indoor_floors - 1)
-    else:
-        # TODO: Incorporate complex garage geometries, see BEopt examples
-        print('WARNING: Indoor floor area calculation is incorrect. Likely due to complex garage geometry.')
-        indoor_floor_area = conditioned_floor_area - first_floor_area * (total_floors - indoor_floors)
+        garage_area_in_main = 0
+
+    indoor_floor_area = conditioned_floor_area - first_floor_area * (total_floors - indoor_floors)
+    indoor_floor_check = first_floor_area + attic_floor_area * (indoor_floors - 1)
+    if abs(indoor_floor_check - indoor_floor_area) > 10:
+        print(f'WARNING: Indoor floor area calculations do not agree: '
+              f'{indoor_floor_area} m^2 and {indoor_floor_check} m^2')
     construction_dict.update({
         'First Floor Area (m^2)': first_floor_area,
-        'Second Floor Area (m^2)': second_floor_area,
+        'Attic Floor Area (m^2)': attic_floor_area,
         'Garage Floor Area (m^2)': garage_floor_area,
+        'Garage Protruded Area (m^2)': garage_floor_area - garage_area_in_main,  # area not in main rectangle
         'Indoor Floor Area (m^2)': indoor_floor_area,
     })
 
@@ -428,12 +440,20 @@ def parse_indoor_infiltration(hpxml, construction, equipment):
 def parse_hpxml_zones(hpxml, boundaries, construction):
     enclosure = hpxml['Enclosure']
     first_floor_area = construction['First Floor Area (m^2)']
-    second_floor_area = construction['Second Floor Area (m^2)']
+    attic_floor_area = construction['Attic Floor Area (m^2)']
     garage_floor_area = construction['Garage Floor Area (m^2)']
+    garage_protruded_area = construction['Garage Protruded Area (m^2)']
     indoor_floor_area = construction['Indoor Floor Area (m^2)']
     ceiling_height = construction['Ceiling Height (m)']
     building_height = ceiling_height * construction['Indoor Floors']
     has_garage = garage_floor_area > 0
+
+    roof_tilt = convert(boundaries['Attic Roof']['Tilt (deg)'], 'deg',
+                        'rad')  # tan(roof_tilt) = height / (width / 2)
+    if 'Garage Roof' in boundaries:
+        garage_tilt = convert(boundaries['Garage Roof']['Tilt (deg)'], 'deg', 'rad')
+    else:
+        garage_tilt = roof_tilt
 
     # Indoor ventilation parameters - Whole ventilation fans only
     # Note: Indoor infiltration parameters depend on equipment, added in add_indoor_infiltration
@@ -479,33 +499,33 @@ def parse_hpxml_zones(hpxml, boundaries, construction):
             # standard gable roof with attic
             assert abs(attic_wall_areas[1] - attic_wall_areas[0]) < 0.2  # computational errors possible
             attic_gable_area = attic_wall_areas[0]
-            garage_gable_area = 0
+            third_gable_area = 0
         elif has_garage and len(attic_wall_areas) == 3:
             # 2 attic gables plus 1 garage gable, garage gable has area that is 'more different'
             attic_gable_area = attic_wall_areas[1]
             low, med, high = tuple(sorted(attic_wall_areas))
-            garage_gable_area = low if med - low > high - med else high
+            third_gable_area = low if med - low > high - med else high
         else:
             raise Exception('Unable to calculate attic area, likely an issue with gable walls.')
 
         # Get attic properties
-        roof_tilt = convert(boundaries['Attic Roof']['Tilt (deg)'], 'deg',
-                            'rad')  # tan(roof_tilt) = height / (width / 2)
         attic_height = (attic_gable_area * math.tan(roof_tilt)) ** 0.5
-        attic_volume = 1 / 2 * second_floor_area * attic_height  # volume = 1/2 l*w*h
-        if garage_gable_area > 0:
+        if third_gable_area > 0:
             # assumes a combined attic, add volume over garage and in between
-            garage_tilt = convert(boundaries['Garage Roof']['Tilt (deg)'], 'deg', 'rad') \
-                if 'Garage Roof' in boundaries else roof_tilt
-            garage_height = (garage_gable_area * math.tan(garage_tilt)) ** 0.5
-            garage_width = 2 * garage_gable_area / garage_height
+            square_area = attic_floor_area - garage_protruded_area
+            garage_height = (third_gable_area * math.tan(garage_tilt)) ** 0.5
+            garage_width = 2 * third_gable_area / garage_height
             # garage_length = garage_floor_area / garage_width
-            garage_depth_in_house = garage_height * math.tan(roof_tilt)  # length from ext wall to roof connection point
-            attic_volume += (1 / 2 * garage_floor_area * garage_height +  # area over garage
-                             1 / 6 * garage_width * garage_depth_in_house * garage_height)  # pyramid between prisms
+            garage_depth_in_house = garage_height * math.tan(roof_tilt)  # length from attached wall to roof connection point
+            attic_volume = (1 / 2 * square_area * attic_height +                           # prism over square
+                            1 / 2 * garage_protruded_area * garage_height +                # prism over garage
+                            1 / 6 * garage_width * garage_depth_in_house * garage_height)  # pyramid between prisms
+        else:
+            attic_volume = 1 / 2 * attic_floor_area * attic_height  # volume = 1/2 l*w*h
+
         vented = attic.get('AtticType', {}).get('Attic', {}).get('Vented', True)
         zones['Attic'] = {
-            'Zone Area (m^2)': first_floor_area + garage_floor_area,
+            'Zone Area (m^2)': attic_floor_area,
             'Volume (m^3)': attic_volume,
             'Vented': vented,
         }
@@ -520,7 +540,7 @@ def parse_hpxml_zones(hpxml, boundaries, construction):
             })
         elif inf_units == 'SLA':
             # Update ELA based on attic area
-            attic_ela = attic['VentilationRate']['Value'] * second_floor_area * 1e4  # m^2 to cm^2
+            attic_ela = attic['VentilationRate']['Value'] * attic_floor_area * 1e4  # m^2 to cm^2
             zones['Attic'].update({
                 'Infiltration Method': 'ELA',
                 'ELA (cm^2)': attic_ela,
@@ -584,7 +604,12 @@ def parse_hpxml_zones(hpxml, boundaries, construction):
     if has_garage:
         # Note: garage roof space is included in attic for 1-story homes
         # FUTURE: convert to ELA? Can use 1sqft at 4.9 SLA = 1.2854145 CFM50, will need to convert ACH50 to ACH
-        garage_volume = garage_floor_area * ceiling_height
+        garage_volume = garage_floor_area * ceiling_height  # excluding garage attic space
+        garage_roof_areas = boundaries.get('Garage Roof', {}).get('Area (m^2)', [])
+        if len(garage_roof_areas) > 0:
+            # add garage roof space - should work for triangle roof or gable roof
+            garage_volume += 1/2 * math.atan(garage_tilt) * garage_protruded_area
+
         indoor_infiltration = list(enclosure['AirInfiltration'].values())[0]
         indoor_ach = indoor_infiltration['BuildingAirLeakage']['AirLeakage']  # ACH50
         zones['Garage'] = {


### PR DESCRIPTION
Adding fixes to garage geometry warnings and errors. Works for 2 BEopt cases with protruding and non-protruding garages. No linked issue.

- [x] Reference the issue your PR is fixing
- [x] Assign at least 1 reviewer for your PR
