### PR TITLE
Envelope_args

### DIFF
--- a/bin/run_dwelling.py
+++ b/bin/run_dwelling.py
@@ -47,8 +47,11 @@ dwelling_args = {
     #     'external_radiation_method': 'linear',
     #     'internal_radiation_method': 'linear',
     #     'reduced_states': 7,
+    #     'save_matrices': True,
+    #     'zones': {'Indoor': {
+    #         'enable_humidity': False,
+    #     }},
     # },
-    # 'save_matrices': True,
 
     # Equipment parameters
     'Equipment': {

--- a/ochre/Dwelling.py
+++ b/ochre/Dwelling.py
@@ -73,7 +73,6 @@ class Dwelling(Simulator):
         # Load occupancy schedule and weather files
         schedule, location = load_schedule(properties, weather_station=weather_station, **house_args)
         properties['location'] = location
-        house_args['schedule'] = schedule
         self.start_time = self.start_time.replace(tzinfo=schedule.index.tzinfo)
 
         # Save HPXML properties to json file
@@ -98,11 +97,11 @@ class Dwelling(Simulator):
             self.print('Saved schedule to:', schedule_output_file)
 
         # Update args for initializing Envelope and Equipment
-        initial_schedule = schedule.loc[self.start_time].to_dict()
         sim_args = {
             **house_args,
             'start_time': self.start_time,  # updates time zone if necessary
-            'initial_schedule': initial_schedule,
+            'schedule': schedule,
+            'initial_schedule': schedule.loc[self.start_time].to_dict(),
             'main_sim_name': self.name,
             'output_path': self.output_path,
         }
@@ -117,7 +116,7 @@ class Dwelling(Simulator):
         sim_args['envelope_model'] = self.envelope
 
         # Add detailed equipment properties, including ZIP parameters
-        equipment_dict = update_equipment_properties(properties, **house_args)
+        equipment_dict = update_equipment_properties(properties, **sim_args)
 
         # Create all equipment
         self.equipment = {}

--- a/ochre/utils/equipment.py
+++ b/ochre/utils/equipment.py
@@ -85,8 +85,9 @@ def get_duct_info(ducts, zones, boundaries, construction, location, **kwargs):
 
 
 def update_equipment_properties(properties, schedule, zip_parameters_file='ZIP Parameters.csv', **kwargs):
-    # split heat pump equipment into heater and cooler
     all_equipment = properties['equipment']
+    
+    # split heat pump equipment into heater and cooler
     for heat_pump_name, short_name in [('Air Source Heat Pump', 'ASHP'),
                                        ('Minisplit Heat Pump', 'MSHP')]:
         if heat_pump_name in all_equipment:

--- a/ochre/utils/hpxml.py
+++ b/ochre/utils/hpxml.py
@@ -1574,8 +1574,13 @@ def load_hpxml(modify_hpxml_dict=None, **house_args):
     # Parse occupancy
     occupancy = parse_hpxml_occupancy(hpxml)
 
-    # Parse envelope properties
+    # Parse envelope properties and merge with house_args
     boundaries, zones, construction = parse_hpxml_envelope(hpxml, occupancy, **house_args)
+    envelope = house_args.get('Envelope', {})
+    if 'boundaries' in envelope:
+        boundaries = nested_update(boundaries, house_args['Envelope'].pop('boundaries'))
+    if 'zones' in envelope:
+        zones = nested_update(zones, house_args['Envelope'].pop('zones'))
 
     # Parse equipment properties and merge with house_args
     equipment_dict = parse_hpxml_equipment(hpxml, occupancy, construction)


### PR DESCRIPTION
Quick fix for parsing Envelope arguments. Zone arguments, e.g. `Thermal Mass Multiplier`, were causing HPXML parameters to get overwritten, which threw an error. This should fix issues with nested dictionary arguments for Envelope zones and boundaries.

No issue created yet.

- [ ] Reference the issue your PR is fixing
- [x] Assign at least 1 reviewer for your PR
