### PR TITLE
Garage-doors

### DIFF
--- a/defaults/Envelope/Envelope Boundaries.csv
+++ b/defaults/Envelope/Envelope Boundaries.csv
@@ -22,6 +22,7 @@ Garage Roof,GR,EXT,GAR
 Garage Ceiling,GC,ATC,GAR
 Garage Interior Ceiling,GI,ATC,GAR
 Garage Floor,GF,GND,GAR
+Garage Door,GD,EXT,GAR
 Garage Furniture,GM,GAR,GAR
 Adjacent Wall,JW,LIV,LIV
 Adjacent Ceiling,JC,LIV,LIV

--- a/defaults/Envelope/Envelope Boundary Types.csv
+++ b/defaults/Envelope/Envelope Boundary Types.csv
@@ -246,6 +246,7 @@ Garage Attached Wall,"WoodStud, wood siding, R-19",wood siding,WoodStud,R-19,res
 Garage Attached Wall,"WoodStud, wood siding, R-7",wood siding,WoodStud,R-7,res3.1_national_300 - bldg0000210,8.73807325330871
 Garage Attached Wall,"WoodStud, wood siding, Uninsulated",wood siding,WoodStud,Uninsulated,res3.1_national_300 - bldg0000003,3.4391278013325257
 Garage Ceiling,Standard,,,,res3.1_national_300 - bldg0000003,0.5699086620495835
+Garage Door,R-5.0,,,,Copied from Door,4.122228
 Garage Floor,2ft R10 Exterior,,,2ft R10 Exterior,copied from Floor,8.350026906372001
 Garage Floor,"2ft R10 Perimeter, R5 Gap",,,2ft R10 Perimeter,copied from Floor,6.657035770547999
 Garage Floor,2ft R5 Exterior,,,2ft R5 Exterior,copied from Floor,6.882918392398

--- a/defaults/Envelope/Envelope Materials.csv
+++ b/defaults/Envelope/Envelope Materials.csv
@@ -955,6 +955,7 @@ Garage Attached Wall,"WoodStud, wood siding, Uninsulated",,,,OSB SHEATHING 0.5 I
 Garage Attached Wall,"WoodStud, wood siding, Uninsulated",,,,WALL STUD AND CAVITY,0.1397,0.335,139.054,,0.4165,22.7328605968244,,1170.238
 Garage Attached Wall,"WoodStud, wood siding, Uninsulated",,,,GYPSUM BOARD,0.0127,0.16,801.0,,0.07923,8.51861898,,837.4
 Garage Ceiling,Standard,,,,CEILING STUD AND CAVITY,0.1397,1.392,65.682,,0.1004,10.804163557136398,,1177.466
+Garage Door,R-5.0,,,,DOOR MATERIAL,0.0445,0.061,512.64,1214.23,0.726,27.69959759,Copied from Door,
 Garage Floor,2ft R10 Exterior,,,2ft R10 Exterior,Ficticious Insulating Layer,0.0,0.0,0.0,0.0,1.217110581,0.0,copied from Floor,
 Garage Floor,2ft R10 Exterior,,,2ft R10 Exterior,Soil,0.3048,1.731,1842.3,0.418752,0.176083189,235.1430836,copied from Floor,
 Garage Floor,2ft R10 Exterior,,,2ft R10 Exterior,Slab,0.1016,1.312675,2242.8,0.837504,0.077399204,190.8407635,copied from Floor,


### PR DESCRIPTION
Fixes #70. 

- Added garage door boundary. Uses the same material as a regular door
- Garage door now removes area from garage wall 
- Added check for all windows and doors to verify their interior zone
- Added check to explicitly not handle garage windows, attic windows, and attic doors. Also added errors for unknown zones (mainly for foundation windows and doors)

- [x] Reference the issue your PR is fixing
- [x] Assign at least 1 reviewer for your PR
