### PR TITLE
PCM-Water.py

### DIFF
--- a/ochre/Models/Water.py
+++ b/ochre/Models/Water.py
@@ -200,7 +200,7 @@ class StratifiedWaterModel(RCModel):
         #         vol_ratio = (self.washer_draw_temp - self.mains_temp) / (self.outlet_temp - self.mains_temp)
         #         self.draw_total += draw_cw * vol_ratio
 
-        t_s = self.time_res
+        t_s = self.time_res.total_seconds()
         draw_liters = self.draw_total * t_s / 60  # in liters
         draw_fraction = draw_liters / self.volume  # unitless
 


### PR DESCRIPTION
Simple PCM model with 12 total nodes, one of which is PCM (bottom of tank). PCM properties only change depending on phase (solid/liquid) in relation to transition temperature. New method added to model to calculate RC parameters of PCM with an if statement to determine PCM phase based on temperature of current timestep. Water heater equipment simulation runs successfully with updated water tank model.

- [x] Reference the issue your PR is fixing
- [x] Assign at least 1 reviewer for your PR
- [x] Test with run_dwelling.py or other script
- [ ] Update documentation as appropriate
- [ ] Update changelog as appropriate
