### PR TITLE
Add c_d calculation and a startup capacity degradation function for A…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 ### OCHRE v0.9.1
 
 - Updated and relaxed dependencies
+- Added capacity degredation for ASHP/MSHP/AC at startup. Time to reach
+  full capacity calculated based on c_d of equipment to explicitly
+  account for cycling losses
 
 ### OCHRE v0.9.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,13 @@
 ## OCHRE Changelog
 
+### Updates from PRs
+
+- Added startup capacity degredation for ASHP/MSHP/AC
+  [#179](https://github.com/NREL/OCHRE/issues/179)
+
 ### OCHRE v0.9.1
 
 - Updated and relaxed dependencies
-- Added capacity degredation for ASHP/MSHP/AC at startup. Time to reach
-  full capacity calculated based on c_d of equipment to explicitly
-  account for cycling losses
 
 ### OCHRE v0.9.0
 

--- a/docs/source/ModelingApproach.rst
+++ b/docs/source/ModelingApproach.rst
@@ -192,6 +192,9 @@ pump heating model includes a few unique features:
    threshold.
 -  A reverse cycle defrost algorithm that reduces heat pump efficiency and
    capacity at low temperatures.
+-  Startup capacity degredation, where it takes several minutes to reach the
+   nominal capacity depending on the coefficient of degredation (c_d) of
+   the heat pump.
 
 All HVAC equipment can be externally controlled by updating the thermostat
 setpoints and deadband or by direct load control (i.e., shut-off). Specific

--- a/docs/source/ModelingApproach.rst
+++ b/docs/source/ModelingApproach.rst
@@ -193,8 +193,8 @@ pump heating model includes a few unique features:
 -  A reverse cycle defrost algorithm that reduces heat pump efficiency and
    capacity at low temperatures.
 -  Startup capacity degredation, where it takes several minutes to reach the
-   nominal capacity depending on the coefficient of degredation (c_d) of
-   the heat pump.
+   nominal capacity depending on the coefficient of degredation of the heat
+   pump.
 
 All HVAC equipment can be externally controlled by updating the thermostat
 setpoints and deadband or by direct load control (i.e., shut-off). Specific

--- a/ochre/Equipment/HVAC.py
+++ b/ochre/Equipment/HVAC.py
@@ -964,9 +964,8 @@ class DynamicHVAC(HVAC):
             # Update capacity using biquadratic model. speed_idx should already be set
             capacity = self.calculate_biquadratic_param(param='cap', speed_idx=self.speed_idx)
             #update capacity for any startup degredation
-            if self.time_res <= dt.timedelta(minutes=2): #5 min is max to full capacity
-                self.startup_cap_mult = self.calc_startup_capacity_degredation()
-                capacity *= self.startup_cap_mult
+            self.startup_cap_mult = self.calc_startup_capacity_degredation()
+            capacity *= self.startup_cap_mult
             return capacity
 
     def update_eir(self):

--- a/ochre/Equipment/HVAC.py
+++ b/ochre/Equipment/HVAC.py
@@ -60,6 +60,7 @@ class HVAC(Equipment):
         self.capacity_min = kwargs.get('Minimum Capacity (W)', 0)  # for ideal equipment, in W
         self.space_fraction = kwargs.get('Conditioned Space Fraction (-)', 1.0)
         self.delivered_heat = 0  # in W, total sensible heat gain, excluding duct losses
+        self.c_d = kwargs.get("Startup Capacity Degradation (-)", 0.0)  # startup capacity degradation factor, unitless
 
         # Efficiency and loss parameters
         if isinstance(kwargs['EIR (-)'], list):
@@ -364,11 +365,10 @@ class HVAC(Equipment):
         
 
     def calc_startup_capacity_degredation(self):
-        c_d = utils_equipment.calc_c_d(self)
-        if c_d == 0.0:
+        if self.c_d == 0.0:
             return 1.0
         else:
-            t_full = 20.0 * c_d + 0.4 ## time to full capacity, in minutes
+            t_full = 20.0 * self.c_d + 0.4 ## time to full capacity, in minutes
             time_full_cap = dt.timedelta(minutes=t_full)
             if "HP" in self.mode:
                 if "HP" not in self.mode_prev: #from off, ER on, etc. to using a HP with capacity degradation

--- a/ochre/Equipment/HVAC.py
+++ b/ochre/Equipment/HVAC.py
@@ -961,7 +961,12 @@ class DynamicHVAC(HVAC):
             return capacity
         else:
             # Update capacity using biquadratic model. speed_idx should already be set
-            return self.calculate_biquadratic_param(param='cap', speed_idx=self.speed_idx)
+            capacity = self.calculate_biquadratic_param(param='cap', speed_idx=self.speed_idx)
+            #update capacity for any startup degredation
+            if self.time_res < 2: #5 min is max to full capacity
+                startup_cap_mult = self.calc_startup_capacity_degredation #JEFF
+                capacity *= startup_cap_mult
+            return capacity
 
     def update_eir(self):
         # Update eir and eir_max using biquadratic model
@@ -1095,9 +1100,6 @@ class HeatPumpHeater(DynamicHVAC, Heater):
         else:
             self.defrost_power_mult = 0
             self.power_defrost = 0
-        if self.time_res < 2: #5 min is max to full capacity
-            startup_cap_mult = self.calc_startup_capacity_degredation #JEFF
-            capacity *= startup_cap_mult
         return capacity
 
     def update_eir(self):

--- a/ochre/Equipment/HVAC.py
+++ b/ochre/Equipment/HVAC.py
@@ -362,40 +362,9 @@ class HVAC(Equipment):
         else:
             return None
         
-    def calc_c_d(self):
-        #Calculate coefficient of degredation (c_d) of equipment based on equipment type and EER/SEER/HSPF
-        #Should only affect cases with single speed and two speed compressor driven equipment (ASHP/AC)
-        #Capacity losses based on Jon Winkler's thesis and match what's in E+ with "Advanced Research Features for startup losses"
-        #https://drum.lib.umd.edu/bitstream/handle/1903/9493/Winkler_umd_0117E_10504.pdf?sequence=1&isAllowed=y page 200
-
-        if self.is_heater:
-            hspf = convert(1 / self.eir, 'W', 'Btu/hour')
-            if self.n_speeds == 1:
-                if hspf < 7.0:
-                    c_d = 0.2
-                else:
-                    c_d = 0.11
-            elif self.n_speeds == 2:
-                c_d = 0.11
-            else:
-                c_d = 0.0 #Do no capacity degradation at startup, since this isn't on/off equipment
-        else: #cooling equipment
-            seer = convert(1 / self.eir, 'W', 'Btu/hour')
-            if self.name =='Room AC':
-                c_d = 0.22
-            elif self.n_speeds == 1:
-                if seer < 13.0:
-                    c_d = 0.2
-                else:
-                    c_d = 0.07
-            elif self.n_speeds == 2:
-                c_d = 0.11
-            else:
-                c_d = 0.0 #Do no capacity degradation at startup, since this isn't on/off equipment
-        return c_d
 
     def calc_startup_capacity_degredation(self):
-        c_d = self.calc_c_d()
+        c_d = utils_equipment.calc_c_d(self)
         if c_d == 0.0:
             return 1.0
         else:

--- a/ochre/utils/equipment.py
+++ b/ochre/utils/equipment.py
@@ -428,37 +428,39 @@ def calculate_duct_dse(hvac, ducts, climate_file='ASHRAE152_climate_data.csv',
 
     return dse
 
-def calc_c_d(hvac):
-    #Calculate coefficient of degredation (c_d) of equipment based on equipment type and EER/SEER/HSPF
-    #Should only affect cases with single speed and two speed compressor driven equipment (ASHP/AC)
-    #Capacity losses based on Jon Winkler's thesis and match what's in E+ with "Advanced Research Features for startup losses"
-    #https://drum.lib.umd.edu/bitstream/handle/1903/9493/Winkler_umd_0117E_10504.pdf?sequence=1&isAllowed=y page 200
 
-    if hvac.is_heater:
-        hspf = convert(1 / hvac.eir, 'W', 'Btu/hour')
-        if hvac.n_speeds == 1:
+def calc_c_d(is_heater, name, cop, number_of_speeds):
+    # Calculate coefficient of degredation (c_d) of equipment based on equipment type and EER/SEER/HSPF
+    # Should only affect cases with single speed and two speed compressor driven equipment (ASHP/AC)
+    # Capacity losses based on Jon Winkler's thesis and match what's in E+ with "Advanced Research Features for startup losses"
+    # https://drum.lib.umd.edu/bitstream/handle/1903/9493/Winkler_umd_0117E_10504.pdf?sequence=1&isAllowed=y page 200
+
+    if is_heater:
+        hspf = convert(cop, "W", "Btu/hour")
+        if number_of_speeds == 1:
             if hspf < 7.0:
                 c_d = 0.2
             else:
                 c_d = 0.11
-        elif hvac.n_speeds == 2:
+        elif number_of_speeds == 2:
             c_d = 0.11
         else:
-            c_d = 0.0 #Do no capacity degradation at startup, since this isn't on/off equipment
+            c_d = 0.0 # Do no capacity degradation at startup, since this isn't on/off equipment
     else: #cooling equipment
-        seer = convert(1 / hvac.eir, 'W', 'Btu/hour')
-        if hvac.name =='Room AC':
+        seer = convert(cop, "W", "Btu/hour")
+        if name =='Room AC':
             c_d = 0.22
-        elif hvac.n_speeds == 1:
+        elif number_of_speeds == 1:
             if seer < 13.0:
                 c_d = 0.2
             else:
                 c_d = 0.07
-        elif hvac.n_speeds == 2:
+        elif number_of_speeds == 2:
             c_d = 0.11
         else:
-            c_d = 0.0 #Do no capacity degradation at startup, since this isn't on/off equipment
+            c_d = 0.0 # Do no capacity degradation at startup, since this isn't on/off equipment
     return c_d
+
 
 # Psychrometric functions for HVAC
 # Originally taken from BEopt python code, author: shorowit

--- a/ochre/utils/equipment.py
+++ b/ochre/utils/equipment.py
@@ -428,6 +428,37 @@ def calculate_duct_dse(hvac, ducts, climate_file='ASHRAE152_climate_data.csv',
 
     return dse
 
+def calc_c_d(hvac):
+    #Calculate coefficient of degredation (c_d) of equipment based on equipment type and EER/SEER/HSPF
+    #Should only affect cases with single speed and two speed compressor driven equipment (ASHP/AC)
+    #Capacity losses based on Jon Winkler's thesis and match what's in E+ with "Advanced Research Features for startup losses"
+    #https://drum.lib.umd.edu/bitstream/handle/1903/9493/Winkler_umd_0117E_10504.pdf?sequence=1&isAllowed=y page 200
+
+    if hvac.is_heater:
+        hspf = convert(1 / hvac.eir, 'W', 'Btu/hour')
+        if hvac.n_speeds == 1:
+            if hspf < 7.0:
+                c_d = 0.2
+            else:
+                c_d = 0.11
+        elif hvac.n_speeds == 2:
+            c_d = 0.11
+        else:
+            c_d = 0.0 #Do no capacity degradation at startup, since this isn't on/off equipment
+    else: #cooling equipment
+        seer = convert(1 / hvac.eir, 'W', 'Btu/hour')
+        if hvac.name =='Room AC':
+            c_d = 0.22
+        elif hvac.n_speeds == 1:
+            if seer < 13.0:
+                c_d = 0.2
+            else:
+                c_d = 0.07
+        elif hvac.n_speeds == 2:
+            c_d = 0.11
+        else:
+            c_d = 0.0 #Do no capacity degradation at startup, since this isn't on/off equipment
+    return c_d
 
 # Psychrometric functions for HVAC
 # Originally taken from BEopt python code, author: shorowit

--- a/ochre/utils/hpxml.py
+++ b/ochre/utils/hpxml.py
@@ -830,9 +830,6 @@ def parse_hvac(hvac_type, hvac_all):
     else:
         aux_power = hvac_ext.get('FanPowerWatts', 0)
 
-    # Get startup capacity degradation factor
-    c_d = utils_equipment.calc_c_d(is_heater, name, cop, number_of_speeds)
-
     out = {
         'Equipment Name': name,
         'Fuel': fuel.capitalize(),
@@ -843,8 +840,12 @@ def parse_hvac(hvac_type, hvac_all):
         'Conditioned Space Fraction (-)': space_fraction,
         'Number of Speeds (-)': number_of_speeds,
         'Rated Auxiliary Power (W)': aux_power,
-        "Startup Capacity Degradation (-)": c_d,
     }
+
+    # Add startup capacity degradation factor for AC and heat pumps
+    if has_heat_pump or not is_heater:
+        c_d = utils_equipment.calc_c_d(is_heater, name, cop, number_of_speeds)
+        out['Startup Capacity Degradation (-)'] = c_d
 
     # Get HVAC setpoints, optional
     controls = hvac_all['HVACControl']


### PR DESCRIPTION
Related to #179. add capacity degradation during startup. Ultimately should affect AC, ASHP, and HPWHs any time the mode changes from something other to 'HP on" to 'HP on'.

This also means we're calculating c_d and correctly calculating cycling losses for equipment. For HPWHs, there's no c_d so we'll have to empirically determine the time to a relatively steady state capacity from lab data.

- [X] Reference the issue your PR is fixing
- [x] Assign at least 1 reviewer for your PR
- [x] Test with run_dwelling.py or other script
- [x] Update documentation as appropriate
- [x] Update changelog as appropriate
