### PR TITLE
Unvented-infiltration-bug

### DIFF
--- a/ochre/Models/Envelope.py
+++ b/ochre/Models/Envelope.py
@@ -364,8 +364,8 @@ class Zone:
 
         # calculate sensible heat gains
         sensible_gain = sensible_flow * density * cp_air * delta_t * 1000  # in W
-        if h_limit is not None and ((sensible_gain < 0) ^ (sensible_gain > h_limit)):
-            # clip sensible gain based on heat gain limit, only in 1 direction
+        if h_limit is not None and abs(sensible_gain) > abs(h_limit):
+            # clip sensible gain based on heat gain limit
             sensible_gain = h_limit
 
         # TODO: add heavy ball convergence to fix high wind issues for attics


### PR DESCRIPTION
Addresses #191. Simple 1 line bug fix for when infiltration sensible gains = 0. This happens when the infiltration method is undefined, which occurs for unvented crawlspaces. 

- [x] Reference the issue your PR is fixing
- [ ] Assign at least 1 reviewer for your PR
- [ ] Test with run_dwelling.py or other script
- [ ] Update documentation as appropriate
- [ ] Update changelog as appropriate
