### PR TITLE
Add test for run_dwelling.py script and fix HPWH initialization bug

### DIFF
--- a/bin/run_dwelling.py
+++ b/bin/run_dwelling.py
@@ -117,6 +117,16 @@ dwelling_args = {
 }
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run a single dwelling simulation")
+    parser.add_argument(
+        "--no-show",
+        action="store_true",
+        help="Save plot to disk but do not display it (useful for CI/automated testing)",
+    )
+    args = parser.parse_args()
+
     # Initialization
     dwelling = Dwelling(**dwelling_args)
 
@@ -127,5 +137,15 @@ if __name__ == "__main__":
     # df, metrics, hourly = Analysis.load_ochre(dwelling_args["output_path"], dwelling_args["name"])
 
     # Plot results
-    CreateFigures.plot_power_stack(df)
-    CreateFigures.plt.show()
+    fig = CreateFigures.plot_power_stack(df)
+
+    # Always save plot to output directory (if plot was created)
+    if fig is not None:
+        output_path = dwelling_args.get("output_path", os.getcwd())
+        plot_file = os.path.join(output_path, f"{dwelling_args['name']}_power_stack.png")
+        fig.savefig(plot_file)
+        print(f"Plot saved to: {plot_file}")
+
+    # Show plot interactively unless --no-show is specified
+    if not args.no_show:
+        CreateFigures.plt.show()

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 - Applied ruff code formatting to entire codebase
 - Fixed ruff lint errors across codebase
 - Updated CI to run tests on all pull requests
+- Fixed bug in HPWH initialization where `hp_cop` was used before defined
+- Added `--no-show` option to `run_dwelling.py` for headless execution
 
 ### OCHRE v0.9.2
 - Restrict pint version to avoid colab issues [#196](https://github.com/NREL/OCHRE/issues/196)

--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -117,7 +117,8 @@ For more examples, see:
 - Python example scripts to:
 
   - Run a `single dwelling
-    <https://github.com/NREL/OCHRE/blob/main/bin/run_dwelling.py>`__
+    <https://github.com/NREL/OCHRE/blob/main/bin/run_dwelling.py>`__ (use
+    ``--no-show`` for headless/CI environments)
 
   - Run a `single piece of equipment
     <https://github.com/NREL/OCHRE/blob/main/bin/run_equipment.py>`__

--- a/ochre/Equipment/WaterHeater.py
+++ b/ochre/Equipment/WaterHeater.py
@@ -449,7 +449,7 @@ class HeatPumpWaterHeater(ElectricResistanceWaterHeater):
             self.hp_capacity_nominal = kwargs["HPWH Capacity (W)"]  # max heating capacity, in W
         else:
             hp_power_nominal = kwargs.get("HPWH Power (W)", 500)  # in W
-            self.hp_capacity_nominal = hp_power_nominal * self.hp_cop  # in W
+            self.hp_capacity_nominal = hp_power_nominal * self.cop_nominal  # in W
         self.parasitic_power = kwargs.get("HPWH Parasitics (W)", 1)  # Standby power in W
         self.fan_power = kwargs.get("HPWH Fan Power (W)", 35)  # in W
 

--- a/test/test_dwelling/test_dwelling.py
+++ b/test/test_dwelling/test_dwelling.py
@@ -2,6 +2,9 @@ import unittest
 import os
 import datetime as dt
 import time
+import subprocess
+import sys
+import glob
 
 from ochre import Dwelling
 from test import test_output_path
@@ -191,6 +194,47 @@ class DwellingWithEquipmentTestCase(unittest.TestCase):
         # check output metrics have expected keys
         self.assertIn("Total Electric Energy (kWh)", metrics)
         self.assertGreater(metrics["Total Electric Energy (kWh)"], 0)
+
+
+class TestRunDwellingScript(unittest.TestCase):
+    """
+    Integration test that runs bin/run_dwelling.py as a subprocess.
+    This validates the example script continues to work end-to-end.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.output_dir = test_output_path
+        cls.script_path = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "bin", "run_dwelling.py")
+
+    @classmethod
+    def tearDownClass(cls):
+        # Clean up output files created by the script
+        patterns = ["MyHouse*.csv", "MyHouse*.parquet", "MyHouse*.png"]
+        for pattern in patterns:
+            for f in glob.glob(os.path.join(cls.output_dir, pattern)):
+                os.remove(f)
+
+    def test_run_dwelling_script(self):
+        """Test that bin/run_dwelling.py runs successfully as a subprocess."""
+        result = subprocess.run(
+            [sys.executable, self.script_path, "--no-show"],
+            cwd=self.output_dir,  # Use test output directory as working directory
+            capture_output=True,
+            text=True,
+            timeout=180,  # 3 minute timeout for initialization + simulation
+        )
+
+        # Check script completed successfully
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Script failed with return code {result.returncode}.\nstdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+        # Check plot file was created
+        plot_file = os.path.join(self.output_dir, "MyHouse_power_stack.png")
+        self.assertTrue(os.path.exists(plot_file), f"Expected plot file not found: {plot_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `--no-show` CLI flag to `bin/run_dwelling.py` for automated testing support
- Always save plots to disk (in addition to optional interactive display)
- Add `TestRunDwellingScript` integration test that runs the script as a subprocess
- Fix bug in `WaterHeater.py` where `self.hp_cop` was used before being defined

## Details

### New Test
The PR template requires "Test with run_dwelling.py or other script". This adds an automated test that validates `bin/run_dwelling.py` works end-to-end by running it as a subprocess with `--no-show` flag.

### Bug Fix
Fixed an `AttributeError` in `HeatPumpWaterHeater.__init__` where `self.hp_cop` was referenced before assignment. This bug was triggered when:
1. Water heater type is "heat pump water heater"
2. `UniformEnergyFactor != 4.9` (so `HPWH Capacity (W)` is not set)

The fix changes `self.hp_cop` to `self.cop_nominal` on line 438, which is equivalent since `self.hp_cop` is later set to `self.cop_nominal` anyway.

## Testing
All 11 dwelling tests pass including the new `TestRunDwellingScript::test_run_dwelling_script`.