### PR TITLE
Fixtures fix

### DIFF
--- a/ochre/Models/Water.py
+++ b/ochre/Models/Water.py
@@ -38,7 +38,7 @@ class StratifiedWaterModel(RCModel):
 
     name = "Water Tank"
     optional_inputs = [
-        "Water Heating (L/min)",
+        "Water Fixtures (L/min)",
         "Clothes Washer (L/min)",
         "Dishwasher (L/min)",
         "Mains Temperature (C)",
@@ -136,7 +136,7 @@ class StratifiedWaterModel(RCModel):
         self.outlet_temp = self.states[self.t_1_idx]  # initial outlet temp, for estimating draw volume
 
         # Note: removing target draw temperature for clothes washers, not implemented in ResStock
-        draw_tempered = self.current_schedule.get("Water Heating (L/min)", 0)
+        draw_tempered = self.current_schedule.get("Water Fixtures (L/min)", 0)
         draw_hot = self.current_schedule.get("Clothes Washer (L/min)", 0) + self.current_schedule.get(
             "Dishwasher (L/min)", 0
         )


### PR DESCRIPTION
A couple of incorrect schedule references to "Water Heater" instead o…f "Water Fixtures". Meant fixtures were getting ignored, introduced when 120V HPWH was added (before any project would have hit this bug).

- [ ] Reference the issue your PR is fixing
- [ ] Assign at least 1 reviewer for your PR
- [x] Test with run_dwelling.py or other script
- [x] Update documentation as appropriate
- [x] Update changelog as appropriate
