### PR TITLE
120 v curve coeff bugfix

### DIFF
--- a/ochre/Equipment/WaterHeater.py
+++ b/ochre/Equipment/WaterHeater.py
@@ -467,12 +467,11 @@ class HeatPumpWaterHeater(ElectricResistanceWaterHeater):
                 self.hp_capacity_coeff = np.array([0.636, 0.0227, 0.000406, -0.000437, 0.0, 0.0])
                 self.cop_coeff = np.array([1.1798, 0.03012, 0.00020632, -0.01935, 0.0001341, 0.0003026])
             else:
-                self.hp_capacity_coeff = np.array([0.813, 0.0160, 0.000537, 0.0020319, -0.0000860, -0.0000686])
-                self.cop_coeff = np.array([1.1332, 0.063, -0.0000979, -0.00972, -0.0000214, -0.000686])
-
+                self.hp_capacity_coeff = np.array([0.563, 0.0437, 0.000039, 0.0055, -0.000148, -0.000145])
+                self.cop_coeff = np.array([1.0132, 0.0436, 0.0000117, -0.01113, 0.00003688, -0.000498])
         else:
-            self.hp_capacity_coeff = np.array([0.563, 0.0437, 0.000039, 0.0055, -0.000148, -0.000145])
-            self.cop_coeff = np.array([1.0132, 0.0436, 0.0000117, -0.01113, 0.00003688, -0.000498])
+            self.hp_capacity_coeff = np.array([0.813, 0.0160, 0.000537, 0.0020319, -0.0000860, -0.0000686])
+            self.cop_coeff = np.array([1.1332, 0.063, -0.0000979, -0.00972, -0.0000214, -0.000686])
 
         # Sensible and latent heat parameters
         self.shr_nominal = kwargs.get("HPWH SHR (-)", 0.88)  # unitless

--- a/ochre/Equipment/WaterHeater.py
+++ b/ochre/Equipment/WaterHeater.py
@@ -467,10 +467,10 @@ class HeatPumpWaterHeater(ElectricResistanceWaterHeater):
                 self.hp_capacity_coeff = np.array([0.636, 0.0227, 0.000406, -0.000437, 0.0, 0.0])
                 self.cop_coeff = np.array([1.1798, 0.03012, 0.00020632, -0.01935, 0.0001341, 0.0003026])
             else:
-                self.hp_capacity_coeff = np.array([0.563, 0.0437, 0.000039, 0.0055, -0.000148, -0.000145])
+                self.hp_capacity_coeff = np.array([0.813, 0.0160, 0.000537, 0.0020319, -0.0000860, -0.0000686])
                 self.cop_coeff = np.array([1.0132, 0.0436, 0.0000117, -0.01113, 0.00003688, -0.000498])
         else:
-            self.hp_capacity_coeff = np.array([0.813, 0.0160, 0.000537, 0.0020319, -0.0000860, -0.0000686])
+            self.hp_capacity_coeff = np.array([0.563, 0.0437, 0.000039, 0.0055, -0.000148, -0.000145])
             self.cop_coeff = np.array([1.1332, 0.063, -0.0000979, -0.00972, -0.0000214, -0.000686])
 
         # Sensible and latent heat parameters

--- a/ochre/Equipment/WaterHeater.py
+++ b/ochre/Equipment/WaterHeater.py
@@ -457,7 +457,6 @@ class HeatPumpWaterHeater(ElectricResistanceWaterHeater):
         self.parasitic_power = kwargs.get("HPWH Parasitics (W)", 1)  # Standby power in W
         self.fan_power = kwargs.get("HPWH Fan Power (W)", 35)  # in W
 
-
         # Dynamic capacity coefficients
         # curve format: [1, t_in_wet, t_in_wet ** 2, t_lower, t_lower ** 2, t_lower * t_in_wet]
         if self.low_power_hpwh:


### PR DESCRIPTION
Spotted by Janelle at School of Mines.

When I added 120V HPWHs in, I messed up which product uses which COP curve. The 120V shared circuit is inappropriately using the 240V COP curve and vice versa.

[Here ](https://github.com/NatLabRockies/OCHRE/blob/0bf050355048a92301ece3122f8e5043889ad81c/ochre/Equipment/WaterHeater.py#L443)is what it was on main when we only supported 240V. [Now ](https://github.com/NatLabRockies/OCHRE/blob/db72dba9800ea0a87f75cad8fc8c0549168f4f84/ochre/Equipment/WaterHeater.py#L473)we have the correct COP curve, matching what was done on main, for the 240V products.
